### PR TITLE
bgpd: Fix "malformed communities" for accept-own-nexthop

### DIFF
--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -677,6 +677,14 @@ community_gettoken(const char *buf, enum community_token *token, uint32_t *val)
 			p += strlen("graceful-shutdown");
 			return p;
 		}
+		if (strncmp(p, "accept-own-nexthop",
+			strlen("accept-own-nexthop"))
+		    == 0) {
+			*val = COMMUNITY_ACCEPT_OWN_NEXTHOP;
+			*token = community_token_accept_own_nexthop;
+			p += strlen("accept-own-nexthop");
+			return p;
+		}
 		if (strncmp(p, "accept-own", strlen("accept-own"))
 		    == 0) {
 			*val = COMMUNITY_ACCEPT_OWN;
@@ -726,14 +734,6 @@ community_gettoken(const char *buf, enum community_token *token, uint32_t *val)
 			*val = COMMUNITY_NO_LLGR;
 			*token = community_token_no_llgr;
 			p += strlen("no-llgr");
-			return p;
-		}
-		if (strncmp(p, "accept-own-nexthop",
-			strlen("accept-own-nexthop"))
-		    == 0) {
-			*val = COMMUNITY_ACCEPT_OWN_NEXTHOP;
-			*token = community_token_accept_own_nexthop;
-			p += strlen("accept-own-nexthop");
 			return p;
 		}
 		if (strncmp(p, "blackhole", strlen("blackhole"))


### PR DESCRIPTION
"set community accept-own-nexthop" returns "malformed communities"
error. This is because the token matching hits an earlier "accept-own"
and leaves "-nexthop" as a separate token to be processed.
Reorder the switch cases so that both are processed correctly.

Signed-off-by: Appu Joseph apjo@kaloom.com